### PR TITLE
Add "Power" tag to more cards.

### DIFF
--- a/content/card-data/oath/en-US/oathbasegame.yml
+++ b/content/card-data/oath/en-US/oathbasegame.yml
@@ -1336,6 +1336,7 @@
   tags:
     - Standard Deck
     - Nomad
+    - Power
 - id: OATH-152
   text: >-
     Move all of your `symbol:favor` to the `symbol:suit-nomad` bank. Any
@@ -1591,6 +1592,7 @@
   tags:
     - Standard Deck
     - Beast
+    - Power
 - id: OATH-181
   text: >-
     **Action**: Kill one warband on the board of a player who has an
@@ -1656,6 +1658,7 @@
   tags:
     - Standard Deck
     - Beast
+    - Power
 - id: OATH-188
   text: >-
     You may play `symbol:suit-beast` and `symbol:suit-hearth` cards to any site


### PR DESCRIPTION
I'm assuming that this tag is meant for cards that have an icon cost to use its power. In that case the following cards were missing that tag:
Convoys
Fae Merchant
War Tortoise

The name of this tag is a bit confusing since Power is a much broader term in Oath. Maybe something like "Cost" would be more fitting?