### PR TITLE
Fix resource type on Arms Interest

### DIFF
--- a/content/card-data/arcs/en-US/blightedreach.yml
+++ b/content/card-data/arcs/en-US/blightedreach.yml
@@ -5883,7 +5883,7 @@
   tags:
     - Blighted Reach
     - Guild
-    - Fuel
+    - Weapon
     - Peacekeeper
   meta:
     keys: 2
@@ -5898,7 +5898,7 @@
   tags:
     - Blighted Reach
     - Guild
-    - Fuel
+    - Weapon
     - Peacekeeper
   meta:
     keys: 2


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a3acfb73-160e-46d9-be8f-76d32b47afc4)

'tis a weapon and not a fuel.