### PR TITLE
Include erratum for Witnesses

### DIFF
--- a/content/errata/arcs/en-US.yml
+++ b/content/errata/arcs/en-US.yml
@@ -77,5 +77,5 @@
     - text: "To improve game flow, add this sentence: 'Scrap this if the Protector is not in play.''"
   card: Unstable Protector
 - errata:
-    - text: "The prelude ability should read 'You may flip a Witness you control at a Psionic planet to its Psionic resource side and take it. **If you do,** you may declare Empath.'"
+    - text: "The Prelude ability should read 'You may flip a Witness you control at a Psionic planet to its Psionic resource side and take it. **If you do,** you may declare Empath.'"
   card: Witnesses

--- a/content/errata/arcs/en-US.yml
+++ b/content/errata/arcs/en-US.yml
@@ -76,3 +76,6 @@
 - errata:
     - text: "To improve game flow, add this sentence: 'Scrap this if the Protector is not in play.''"
   card: Unstable Protector
+- errata:
+    - text: "The prelude ability should read 'You may flip a Witness you control at a Psionic planet to its Psionic resource side and take it. **If you do,** you may declare Empath.'"
+  card: Witnesses


### PR DESCRIPTION
Fix #41 

Marking as draft since i'm not quite sure if the format is correct: 
Some errata end in `''"` with only one corresponding opening single quote `'`. I went with what seemed most reasonable to me.
