### PR TITLE
Add Blight Society errata (#65)

### DIFF
--- a/content/errata/arcs/en-US.yml
+++ b/content/errata/arcs/en-US.yml
@@ -131,3 +131,6 @@
 - errata:
     - text: "The text 'They can't Catapult' should be in body text, not in italics and parentheses."
   card: Blight Fury
+- errata:
+    - text: "The text 'They can't Catapult' should be in body text, not in italics and parentheses."
+  card: Blight Society

--- a/content/faq/arcs/en-US.yml
+++ b/content/faq/arcs/en-US.yml
@@ -599,7 +599,7 @@
         In the Call to Order, if I want to force the Advocate to give me a Guild card, how many Favors do I need to return to them?
       a: >-
         Only the Favors needed for the Transfer Guild Support action; so if the Guild card in question has two keys, then two Favors. You do not need to give them another Favor to get Advocate consent.
-  card: Monopoly Consent
+  card: Guild Negotiations
 - faq:
     - q: >-
         If $link:Blight Hunger$ is in play, where do destroyed pieces go?


### PR DESCRIPTION
- Blight Society should have the same errata as Blight Fury ("They can't Catapult")
- Fix wrong card name in FAQ file