### PR TITLE
Fix typo in card name

### DIFF
--- a/content/card-data/arcs/en-US/blightedreach.yml
+++ b/content/card-data/arcs/en-US/blightedreach.yml
@@ -2332,7 +2332,7 @@
      
     **Prelude:** You may attach this to a Court card with no agents to declare the Warlord ambition.
   image: F407
-  name: Weapon Liaisons
+  name: Weapons Liaisons
   tags:
     - Blighted Reach
     - Guild


### PR DESCRIPTION
The printed title for this card says "Weapon**s**"

https://cards.ledergames.com/card/ARCS-F407